### PR TITLE
Crawl for geom_alt prop updates

### DIFF
--- a/data/856/327/37/85632737.geojson
+++ b/data/856/327/37/85632737.geojson
@@ -193,6 +193,9 @@
         "wof:hierarchy"
     ],
     "wof:country":"MF",
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"5a65e7bb1e8388b4bfab0303caeb0693",
     "wof:hierarchy":[
         {
@@ -209,7 +212,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1561840609,
+    "wof:lastmodified":1582393295,
     "wof:name":"Saint Martin",
     "wof:parent_id":1126128723,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.