### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/112/612/872/3/1126128723.geojson
+++ b/data/112/612/872/3/1126128723.geojson
@@ -25,6 +25,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0645\u0627\u0631\u062a\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646\u062a \u0645\u0627\u0631\u062a\u0646"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0421\u0432\u044f\u0442\u043e\u0433\u0430 \u041c\u0430\u0440\u0446\u0456\u043d\u0430"
     ],
@@ -42,6 +45,12 @@
     ],
     "name:ces_x_preferred":[
         "Svat\u00fd Martin"
+    ],
+    "name:cos_x_preferred":[
+        "San Martinu"
+    ],
+    "name:cym_x_preferred":[
+        "Sant Martin"
     ],
     "name:dan_x_preferred":[
         "Saint Martin"
@@ -106,6 +115,9 @@
     "name:fry_x_preferred":[
         "Sint Marten"
     ],
+    "name:gle_x_preferred":[
+        "Saint-Martin"
+    ],
     "name:gom_x_preferred":[
         "Saint Martin"
     ],
@@ -123,6 +135,9 @@
     ],
     "name:hun_x_preferred":[
         "Szent M\u00e1rton-sziget"
+    ],
+    "name:ido_x_preferred":[
+        "Santa Martin"
     ],
     "name:ina_x_preferred":[
         "Sancte Martin"
@@ -217,6 +232,9 @@
     "name:sco_x_preferred":[
         "Saunt Martin"
     ],
+    "name:shn_x_preferred":[
+        "\u101e\u1035\u1004\u103a\u1089\u1019\u1083\u1087\u1010\u102d\u107c\u103a\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0db8\u0dcf\u0dbb\u0dca\u0da7\u0dd2\u0db1\u0dca"
     ],
@@ -246,6 +264,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba3\u0bcd\u0b9f\u0bcd \u0bae\u0bbe\u0bb0\u0bcd\u0b9f\u0bcd\u0b9f\u0bbf\u0ba9\u0bcd"
+    ],
+    "name:tat_x_preferred":[
+        "\u0421\u0435\u043d-\u041c\u0430\u0440\u0442\u0435\u043d"
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c2e\u0c3e\u0c30\u0c4d\u0c1f\u0c3f\u0c28\u0c4d"
@@ -466,7 +487,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1617827728,
+    "wof:lastmodified":1690939371,
     "wof:name":"Saint Martin",
     "wof:parent_id":102191575,
     "wof:placetype":"dependency",

--- a/data/856/738/79/85673879.geojson
+++ b/data/856/738/79/85673879.geojson
@@ -34,6 +34,9 @@
     "name:ara_x_preferred":[
         "\u0633\u0627\u0646\u062a \u0645\u0627\u0631\u062a\u0646"
     ],
+    "name:arz_x_preferred":[
+        "\u0633\u0627\u0646\u062a \u0645\u0627\u0631\u062a\u0646"
+    ],
     "name:bel_x_preferred":[
         "\u0412\u043e\u0441\u0442\u0440\u0430\u045e \u0421\u0432\u044f\u0442\u043e\u0433\u0430 \u041c\u0430\u0440\u0446\u0456\u043d\u0430"
     ],
@@ -54,6 +57,12 @@
     ],
     "name:ces_x_preferred":[
         "Svat\u00fd Martin"
+    ],
+    "name:cos_x_preferred":[
+        "San Martinu"
+    ],
+    "name:cym_x_preferred":[
+        "Sant Martin"
     ],
     "name:dan_x_preferred":[
         "Saint Martin"
@@ -105,6 +114,9 @@
     "name:fry_x_preferred":[
         "Sint Marten"
     ],
+    "name:gle_x_preferred":[
+        "Saint-Martin"
+    ],
     "name:gom_x_preferred":[
         "Saint Martin"
     ],
@@ -122,6 +134,9 @@
     ],
     "name:hun_x_preferred":[
         "Szent M\u00e1rton-sziget"
+    ],
+    "name:ido_x_preferred":[
+        "Santa Martin"
     ],
     "name:ina_x_preferred":[
         "Sancte Martin"
@@ -217,6 +232,9 @@
     "name:sco_x_preferred":[
         "Saunt Martin"
     ],
+    "name:shn_x_preferred":[
+        "\u101e\u1035\u1004\u103a\u1089\u1019\u1083\u1087\u1010\u102d\u107c\u103a\u1087"
+    ],
     "name:sin_x_preferred":[
         "\u0dc1\u0dcf\u0db1\u0dca\u0dad \u0db8\u0dcf\u0dbb\u0dca\u0da7\u0dd2\u0db1\u0dca"
     ],
@@ -232,6 +250,9 @@
     "name:sqi_x_preferred":[
         "Sh\u00ebn Martini"
     ],
+    "name:srd_x_preferred":[
+        "Saint Martin"
+    ],
     "name:srp_x_preferred":[
         "\u0421\u0432\u0435\u0442\u0438 \u041c\u0430\u0440\u0442\u0438\u043d"
     ],
@@ -243,6 +264,9 @@
     ],
     "name:tam_x_preferred":[
         "\u0b9a\u0bc6\u0baf\u0bbf\u0ba3\u0bcd\u0b9f\u0bcd \u0bae\u0bbe\u0bb0\u0bcd\u0b9f\u0bcd\u0b9f\u0bbf\u0ba9\u0bcd"
+    ],
+    "name:tat_x_preferred":[
+        "\u0421\u0435\u043d-\u041c\u0430\u0440\u0442\u0435\u043d"
     ],
     "name:tel_x_preferred":[
         "\u0c38\u0c46\u0c2f\u0c3f\u0c02\u0c1f\u0c4d \u0c2e\u0c3e\u0c30\u0c4d\u0c1f\u0c3f\u0c28\u0c4d"
@@ -276,6 +300,9 @@
     ],
     "name:war_x_preferred":[
         "Saint Martin"
+    ],
+    "name:wuu_x_preferred":[
+        "\u5723\u9a6c\u4e01\u5c9b"
     ],
     "name:yor_x_preferred":[
         "Saint Martin"
@@ -410,7 +437,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1636506408,
+    "wof:lastmodified":1690939371,
     "wof:name":"St. Martin",
     "wof:parent_id":1126128723,
     "wof:placetype":"region",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.