### PR TITLE
mf concordances, placetype local, and more

### DIFF
--- a/data/112/612/872/3/1126128723.geojson
+++ b/data/112/612/872/3/1126128723.geojson
@@ -468,10 +468,12 @@
     "wof:concordances":{
         "digitalenvoy:country_code":663,
         "gp:id":56042305,
+        "iso:code":"MF",
         "ne:id":1159320639,
         "qs_pg:id":482974,
         "wd:id":"Q25596"
     },
+    "wof:concordances_official":"iso:code",
     "wof:controlled":[
         "wof:hierarchy",
         "wof:parent_id"
@@ -492,7 +494,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1694639811,
+    "wof:lastmodified":1695881383,
     "wof:name":"Saint Martin",
     "wof:parent_id":102191575,
     "wof:placetype":"dependency",

--- a/data/856/738/79/85673879.geojson
+++ b/data/856/738/79/85673879.geojson
@@ -7,7 +7,7 @@
     "edtf:inception":"uuuu",
     "edtf:superseded":"2016-06-22",
     "geom:area":0.005828,
-    "geom:area_square_m":68505762.342398,
+    "geom:area_square_m":68505769.991071,
     "geom:bbox":"-63.14684,18.033391,-63.010732,18.122138",
     "geom:latitude":18.07762,
     "geom:longitude":-63.055072,
@@ -416,11 +416,13 @@
         "gn:id":3578419,
         "gp:id":56042305,
         "hasc:id":"MF.SM",
+        "iso:code_pseudo":"MF",
         "qs_pg:id":482974,
         "wd:id":"Q25596"
     },
+    "wof:concordances_official":"iso:code_pseudo",
     "wof:country":"MF",
-    "wof:geomhash":"e2249a849d7f00caea3e166460dd6b8e",
+    "wof:geomhash":"3089be9e772c50b38b0e8683ef735a42",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -437,7 +439,7 @@
     "wof:lang_x_spoken":[
         "fra"
     ],
-    "wof:lastmodified":1690939371,
+    "wof:lastmodified":1695884972,
     "wof:name":"St. Martin",
     "wof:parent_id":1126128723,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.